### PR TITLE
Stick popover at the beginning of the key

### DIFF
--- a/Lin/Lin.m
+++ b/Lin/Lin.m
@@ -439,9 +439,10 @@ static NSUInteger keyRangeInLineIndices[] = { 1, 1, 1, 1, 1 };
 
         if(matched) {
             NSRange entityRange = NSMakeRange(lineRange.location + entityRangeInLine.location, entityRangeInLine.length);
+            NSRange keyRange = NSMakeRange(lineRange.location + keyRangeInLine.location, keyRangeInLine.length);
 
             if(entityRange.location <= selectedRange.location && selectedRange.location <= (entityRange.location + entityRange.length)) {
-                NSRect selectionRectOnScreen = [textView firstRectForCharacterRange:entityRange];
+                NSRect selectionRectOnScreen = [textView firstRectForCharacterRange:NSMakeRange(keyRange.location, 1)];
                 NSRect selectionRectInWindow = [textView.window convertRectFromScreen:selectionRectOnScreen];
                 NSRect selectionRectInView = [textView convertRect:selectionRectInWindow fromView:nil];
 


### PR DESCRIPTION
This makes the popover stick at the beginning of the key string.

![out](https://f.cloud.github.com/assets/22321/1063601/0d2b7534-12d1-11e3-8140-2bdf7271f469.png)
