### PR TITLE
fix crash on index bounds

### DIFF
--- a/Lin/DVTTextCompletionController+Lin.m
+++ b/Lin/DVTTextCompletionController+Lin.m
@@ -24,10 +24,15 @@
 
 - (BOOL)lin_acceptCurrentCompletion
 {
+  
     // Get selected completion
     DVTTextCompletionSession *session = self.currentSession;
-    id selectedCompletion = session.filteredCompletionsAlpha[session.selectedCompletionIndex];
-    
+    id selectedCompletion = nil;
+  
+    if (session.selectedCompletionIndex < session.filteredCompletionsAlpha.count) {
+      selectedCompletion = session.filteredCompletionsAlpha[session.selectedCompletionIndex];
+    }
+  
     // Original method must be called after referencing selected completion
     BOOL acceptCurrentCompletion = [self lin_acceptCurrentCompletion];
     


### PR DESCRIPTION
Exception Type:        EXC_CRASH (SIGABRT)
Exception Codes:       0x0000000000000000, 0x0000000000000000

Application Specific Information:
ProductBuildVersion: 6C131e
UNCAUGHT EXCEPTION (NSRangeException): *** -[__NSArrayI objectAtIndex:]: index 9223372036854775807 beyond bounds for empty array
UserInfo: (null)
Hints: None
Backtrace:
  0  0x00007fff81bd4654 __exceptionPreprocess (in CoreFoundation)
  1  0x000000010deeb764 DVTFailureHintExceptionPreprocessor (in DVTFoundation)
  2  0x00007fff875d476e objc_exception_throw (in libobjc.A.dylib)
  3  0x00007fff81aad7de -[__NSArrayI objectAtIndex:] (in CoreFoundation)
  4  0x000000011af60ccf -[DVTTextCompletionController(Lin) lin_acceptCurrentCompletion] at /Users/vhosune/Library/Application Support/Alcatraz/Plug-ins/Lin/Lin/DVTTextCompletionController+Lin.m:25 (in Lin)