### PR TITLE
add Xcode 7.3 (7D175) DVTPlugInCompatibilityUUID

### DIFF
--- a/Lin/Info.plist
+++ b/Lin/Info.plist
@@ -22,6 +22,7 @@
 	<string>1</string>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
+		<string>ACA8656B-FEA8-4B6D-8E4A-93F4C95C362C</string>
 		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 		<string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>


### PR DESCRIPTION
Add support for the latest Xcode 7.3 (7D175).

Closes #54 #56 #57 #58 
